### PR TITLE
Simplify display of meta information for projects

### DIFF
--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -21,55 +21,48 @@
         </div>    
         <div class="col-md-4 sidebar">  
           <p class="fs-5 fw-semibold "style="margin: 1em;">Project Profile </p>      
-          <div class="list-group list-group-flush border-bottom scrollarea">
-            {% if page.Topics %}
-            <span class="list-group-item list-group-item-action py-3 lh-tight" aria-current="true">
-              <div class="d-flex w-100 align-items-center justify-content-between">
-                <strong class="mb-1">Topics</strong>
-              </div>
-              <div class="col-12 mb-1 small">{{ page.Topics }}</div>
-            </span>
+          <div class="list-group list-group-flush border-bottom scrollarea">        
+            {% for var in page %}
+            {% if var != "next" and 
+                  var != "path" and
+                  var != "id" and
+                  var != "tags" and
+                  var != "content" and
+                  var != "previous" and
+                  var != "output" and
+                  var != "url" and
+                  var != "relative_path" and
+                  var != "title" and
+                  var != "categories" and
+                  var != "date" and
+                  var != "excerpt" and
+                  var != "draft" and
+                  var != "layout" and
+                  var != "toc" and
+                  var != "slug" and
+                  var != "ext" and
+                  var != "collection"                   
+                  %}
+              {% if var == "Link" %}
+                <span class="list-group-item list-group-item-action py-3 lh-tight" aria-current="true">
+                  <div class="d-flex w-100 align-items-center justify-content-between">
+                    <strong class="mb-1">{{ var }}</strong>
+                  </div>
+                  <div class="col-12 mb-1 small"><a href="{{ page[var] }}">{{ page[var] }}</a></div>
+                </span> 
+               
+              {% else %}
+                <span class="list-group-item list-group-item-action py-3 lh-tight" aria-current="true">
+                  <div class="d-flex w-100 align-items-center justify-content-between">
+                    <strong class="mb-1">{{ var }}</strong>
+                  </div>
+                  <div class="col-12 mb-1 small">{{ page[var] }}</div>
+                </span> 
+              {% endif %}
             {% endif %}
-            {% if page.Keywords %}
-            <span  class="list-group-item list-group-item-action py-3 lh-tight">
-              <div class="d-flex w-100 align-items-center justify-content-between">
-                <strong class="mb-1">Keywords</strong>
-              </div>
-              <div class="col-12 mb-1 small">{{ page.Keywords | join: ', ' | escape }}</div>
-            </span>
-            {% endif %}
-            {% if page.Project_Head %}
-            <span class="list-group-item list-group-item-action py-3 lh-tight">
-              <div class="d-flex w-100 align-items-center justify-content-between">
-                <strong class="mb-1">Project Head</strong>
-              </div>
-              <div class="col-12 mb-1 small">{{ page.Project_Head }}</div>
-            </span>
-            {% endif %}
-            {% if page.Members %}
-            <span class="list-group-item list-group-item-action py-3 lh-tight">
-              <div class="d-flex w-100 align-items-center justify-content-between">
-                <strong class="mb-1">Members</strong>
-              </div>
-              <div class="col-12 mb-1 small">{{ page.Members | join: ', ' | escape }}</div>
-            </span>
-            {% endif %}
-            {% if page.link %}
-            <span class="list-group-item list-group-item-action py-3 lh-tight">
-              <div class="d-flex w-100 align-items-center justify-content-between">
-                <strong class="mb-1">Website</strong>
-              </div>
-              <div class="col-12 mb-1 small"><a href="{{ page.link }}">{{ page.link }}</a></div>
-            </span>
-            {% endif %}
-            {% if page.Status %}
-            <span class="list-group-item list-group-item-action py-3 lh-tight">
-              <div class="d-flex w-100 align-items-center justify-content-between">
-                <strong class="mb-1">Status</strong>
-              </div>
-              <div class="col-12 mb-1 small">{{ page.Status }}</div>
-            </span>
-            {% endif %}        
+            {% endfor %}
+            
+           
           </div> 
           
           {% if page.toc == true %}  

--- a/_projects/4c.md
+++ b/_projects/4c.md
@@ -2,7 +2,7 @@
 layout: project
 title: 4C - Comprehensive Computational Community Code
 Topics: Numerical Simulation, Finite Elements
-Project_Head: Anh-Tu Vuong, Christian Cyron
+Project Head: Anh-Tu Vuong, Christian Cyron
 Members: Developers from Institute of Material Systems Modeling (Hereon), Institute for Computational Mechanics (TU Muenchen, Munich), Institute for Mathematics and Computer-Based Simulation (Universitaet der Bundeswehr, Munich) 
 toc: true
 ---

--- a/_projects/dealii.md
+++ b/_projects/dealii.md
@@ -1,7 +1,7 @@
 ---
 layout: project
 title: deal.II - an open source finite element library
-Project_Head: Peter Munch (Hereon) is one of the principal developers mostly involved in the HPC and linear algebra aspects of the library
+Project Head: Peter Munch (Hereon) is one of the principal developers mostly involved in the HPC and linear algebra aspects of the library
 Members: World-wide team of developers
 Link: https://www.dealii.org/
 toc: true

--- a/_projects/fleur.md
+++ b/_projects/fleur.md
@@ -3,7 +3,7 @@ layout: project
 title: FLEUR
 Topics: All-electron Density Functional Theory, Materials Science, Solid State Physics
 link: https://www.flapw.de
-Project_Head: Stefan Blügel, Daniel Wortmann
+Project Head: Stefan Blügel, Daniel Wortmann
 Members: Gregor Michalicek, Uliana Alekseeva, Christian R. Gerhorst
 toc: true
 ---

--- a/_projects/heat.md
+++ b/_projects/heat.md
@@ -2,7 +2,7 @@
 layout: project
 title: Heat - The Helmholtz Analytics Toolkit
 Topics: High-performance Data Analysis, Machine Learning, Distributed Tensors, Python, MPI, GPU
-Project_Head: Markus Götz
+Project Head: Markus Götz
 Members: KIT-SCC, FZJ-JSC, DLR-SC
 link: https://github.com/helmholtz-analytics/heat/
 toc: true

--- a/_projects/nest.md
+++ b/_projects/nest.md
@@ -2,14 +2,14 @@
 layout: project
 title: NEST Simulator – spiking neural network simulations
 Topics: neuroscience, simulation, spiking neural networks, learning, brain function
-Project_Head: https://nest-initiative.org
+Project Head: https://nest-initiative.org
 Contact: users@nest-simulator.org
 Members: https://github.com/orgs/nest/people and https://nest-initiative.org
 Link: https://nest-simulator.org
-Research_Field: Information
-Scientific_Community: Biology, Medicine, AI
+Research Field: Information
+Scientific Community: Biology, Medicine, AI
 Funding: See https://github.com/nest/nest-simulator/blob/master/ACKNOWLEDGMENTS.md
-Programming_Languages: C++, Python
+Programming Languages: C++, Python
 License: GPL-2.0-or-later
 Cite:  <a href="https://doi.org/10.5281/zenodo.5886894" alt="NEST 3.2"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.5886894.svg" alt="DOI"></a>
 toc: true

--- a/_projects/pffrg.md
+++ b/_projects/pffrg.md
@@ -2,7 +2,7 @@
 layout: project
 title: PFFRG for quantum magnetic systems
 Topics: Condensed matter physics, quantum magnetism, functional renormalization group methods
-Project_Head: Johannes Reuther
+Project Head: Johannes Reuther
 Members: Nils Niggemann, Vincent Noculak
 toc: true
 ---


### PR DESCRIPTION
The layout for projects is changed so that not only individual meta information is displayed, but all of them in the page header. Thereby the order specified there is reproduced.
A meta-key does not have to contain an underscore, but can also be written with spaces, which simplifies the display on the web page.  

Fix issue #3 