### PR TITLE
Split page for partners and allies into separate pages

### DIFF
--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -2,6 +2,8 @@
   link: /
 - name: Partners
   link: /partners.html
+- name: Allies
+  link: /allies.html
 - name: Codes
   link: /codes.html
 - name: Events

--- a/_layouts/allies.html
+++ b/_layouts/allies.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: "en-US" }}">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="utf-8">
+    <title>{{ page.title }} - {{ site.title }}</title>
+    <link rel="stylesheet" type="text/css" href="{{ "/assets/css/main.css" | relative_url }}">
+    <link rel="icon" type="image/png"  href="{{ "/assets/favicon.ico" | relative_url }}">
+  </head>
+  <body>
+    {% include jumbotron_small.html %}
+    {% include navbar.html %}
+    <main>
+       
+    <div class="container">
+      <ul>
+        {% for post in site.posts %}
+          <li>
+            <a href="{{ post.url }}">{{ post.title }}</a>
+          </li>
+        {% endfor %}
+      </ul>
+      {{ content }}
+    </div>
+    {% include footer.html %} 
+    </main>
+  </body>
+</html>

--- a/allies.md
+++ b/allies.md
@@ -1,0 +1,33 @@
+---
+layout: allies
+title: Allies
+---
+
+# HiRSE_PS Allies
+
+<div> <a href="https://www.hifis.net/"><img width="300" src="assets/HIFIS_Logo_short_RGB_cropped.svg"></a> </div>
+<br/>
+
+The top position of Helmholtz research is increasingly based on cross-centre and international cooperation and common access to data treasure and -services. At the same time, the significance of a sustainable software development for the research process is recognised.
+
+**HIFIS builds and sustains an excellent IT infrastructure connecting all Helmholtz research fields and centres.**
+
+This includes the Helmholtz Cloud, where members of the Helmholtz Association of German Research Centres provide selected IT-Services for joint use. HIFIS further supports Research Software Engineering (RSE) with a high level of quality, visibility and sustainability.
+
+The HIFIS clusters develop technologies, processes and policy frameworks for harmonized access to fundamental backbone services, such as Helmholtz AAI, and Helmholtz Cloud services. HIFIS Software also provides education, technology, consulting and community services.
+
+**Helmholtz Digital Services for Science — Collaboration made easy.**
+
+---
+<div> <a href="https://de-rse.org/"><img width="300" src="assets/de-RSE-logo-text-colour-en.png"></a> </div>
+
+Software development is an essential, integral part of research activity. Research software increasingly supports the acquisition, processing and analysis of empirical data, but also the modeling and the simulation of complex processes. Thus, software has a significant influence on the quality of research results. The British Software Sustainability Institute (SSI) has coined the slogan “Better Software - Better Research”.
+
+However, the current approaches to research software as well as the recognition of research software engineering do not adequately reflect the importance of this work in and for the research process. Researchers, scientists and others developing software in and for research within the German scientific landscape have come together in the de-RSE community in order to considerably boost the visibility of these issues, and to decisively improve the current situation. de-RSE aims at constituting a wider initiative for acting jointly on shared objectives, and being the collective spokesperson for RSEs within the German scientific landscape.
+
+---
+<div> <a href="https://os.helmholtz.de/en"><img width="300" src="assets/HGF-OS.jpg"></a> </div>
+
+Guided by the motto "Enabling open science practices in Helmholtz!" the Helmholtz Open Science Office works within the Association and promotes the visibility of Helmholtz on a national as well as international level within the context of Open Science in the spirit of the Helmholtz mission.
+
+The mission of the Helmholtz Open Science Office is to promote the cultural change towards open science. The office, established by the Helmholtz Association in 2005, sees itself as a service provider that supports the community in shaping the cultural change towards open science. The Helmholtz Open Science Office is a partner of all stakeholders involved in this process within Helmholtz.

--- a/partners.md
+++ b/partners.md
@@ -40,32 +40,3 @@ Materials for a sustainable energy supply and operation of the electron storage 
 HZB has existed since 2009. Its roots go much further into the past, given that HZB arose from the fusion of two older research institutions, the former Hahn-Meitner-Institut (est. 1959) and BESSY GmbH (est. 1979). With approximately 1,100 employees, HZB is now one of the largest non-university research centres in Berlin, and a member of the Helmholtz Association. HZB conducts research at two locations, in Wannsee and Adlershof.
 <br/>
 
----
-# HiRSE_PS Allies
-
-<div> <a href="https://www.hifis.net/"><img width="300" src="assets/HIFIS_Logo_short_RGB_cropped.svg"></a> </div>
-<br/>
-
-The top position of Helmholtz research is increasingly based on cross-centre and international cooperation and common access to data treasure and -services. At the same time, the significance of a sustainable software development for the research process is recognised.
-
-**HIFIS builds and sustains an excellent IT infrastructure connecting all Helmholtz research fields and centres.**
-
-This includes the Helmholtz Cloud, where members of the Helmholtz Association of German Research Centres provide selected IT-Services for joint use. HIFIS further supports Research Software Engineering (RSE) with a high level of quality, visibility and sustainability.
-
-The HIFIS clusters develop technologies, processes and policy frameworks for harmonized access to fundamental backbone services, such as Helmholtz AAI, and Helmholtz Cloud services. HIFIS Software also provides education, technology, consulting and community services.
-
-**Helmholtz Digital Services for Science — Collaboration made easy.**
-
----
-<div> <a href="https://de-rse.org/"><img width="300" src="assets/de-RSE-logo-text-colour-en.png"></a> </div>
-
-Software development is an essential, integral part of research activity. Research software increasingly supports the acquisition, processing and analysis of empirical data, but also the modeling and the simulation of complex processes. Thus, software has a significant influence on the quality of research results. The British Software Sustainability Institute (SSI) has coined the slogan “Better Software - Better Research”.
-
-However, the current approaches to research software as well as the recognition of research software engineering do not adequately reflect the importance of this work in and for the research process. Researchers, scientists and others developing software in and for research within the German scientific landscape have come together in the de-RSE community in order to considerably boost the visibility of these issues, and to decisively improve the current situation. de-RSE aims at constituting a wider initiative for acting jointly on shared objectives, and being the collective spokesperson for RSEs within the German scientific landscape.
-
----
-<div> <a href="https://os.helmholtz.de/en"><img width="300" src="assets/HGF-OS.jpg"></a> </div>
-
-Guided by the motto "Enabling open science practices in Helmholtz!" the Helmholtz Open Science Office works within the Association and promotes the visibility of Helmholtz on a national as well as international level within the context of Open Science in the spirit of the Helmholtz mission.
-
-The mission of the Helmholtz Open Science Office is to promote the cultural change towards open science. The office, established by the Helmholtz Association in 2005, sees itself as a service provider that supports the community in shaping the cultural change towards open science. The Helmholtz Open Science Office is a partner of all stakeholders involved in this process within Helmholtz.


### PR DESCRIPTION
Split the page showing the partners involved in HiRSE_PS and the allies into separate pages. This is intended to improve readability and make the individual categories easier find and accessible.