### PR TITLE
Fix showing seminar series and events on main page

### DIFF
--- a/_events/2022_02_07-kickoff.md
+++ b/_events/2022_02_07-kickoff.md
@@ -1,8 +1,7 @@
 ---
 layout: events
 title:  "HiRSE_PS Kickoff Meeting"
-start_date: 07.02.2022
-end_date: 07.02.2022
+start_date: 2022-02-07
 link: none
 location: virtual
 excerpt_separator: <!--more-->

--- a/_events/2022_06_01-livemeeting.md
+++ b/_events/2022_06_01-livemeeting.md
@@ -1,8 +1,8 @@
 ---
 layout: events
 title:  "HiRSE_PS Live Meeting"
-start_date: 01.06.2022
-end_date: 02.06.2022
+start_date: 2022-06-01
+end_date: 2022-06-02
 link: 
 location: https://goo.gl/maps/AyDXUQWHTyQJzJPC7
 excerpt_separator: <!--more-->

--- a/_events/2022_09_22-ci-hackfest_1.md
+++ b/_events/2022_09_22-ci-hackfest_1.md
@@ -1,8 +1,8 @@
 ---
 layout: events
 title:  "1st HiRSE_PS CI Hackfest"
-start_date: 22.09.2022
-end_date: 23.09.2022
+start_date: 2022-09-22
+end_date: 2022-09-23
 location: https://goo.gl/maps/iWnxuUWEPinQoHh28
 excerpt_separator: <!--more-->
 ---

--- a/_events/2023_04_19-livemeeting.md
+++ b/_events/2023_04_19-livemeeting.md
@@ -1,8 +1,8 @@
 ---
 layout: events
 title:  "2nd HiRSE_PS Live Meeting"
-start_date: 19.04.2023
-end_date: 20.04.2023
+start_date: 2023-04-19
+end_date: 2023-04-20
 link: 
 location: https://goo.gl/maps/Ndf22uS6XKwQcP9s7
 excerpt_separator: <!--more-->

--- a/_events/2023_10_17-ci-hackfest_2.md
+++ b/_events/2023_10_17-ci-hackfest_2.md
@@ -1,8 +1,8 @@
 ---
 layout: events
 title:  "HiRSE_PS CB Hackfest"
-start_date: 17.10.2023
-end_date: 18.10.2023
+start_date: 2023-10-17
+end_date: 2023-10-18
 location: https://goo.gl/maps/RmPLrdMrbK3TSqwg8
 excerpt_separator: <!--more-->
 ---

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,7 +21,11 @@
         <div class="col-md-4 sidebar"> 
 
           {% if site.events %}
-          {% assign all_events = site.events |  reverse %}
+          {% if site.series %}
+            {% assign all_events = site.events | concat: site.series |  sort: "start_date" | reverse %}
+          {% else %}
+            {% assign all_events = site.events |  sort: "start_date" | reverse %}
+          {% endif %}
           <p class="fs-5 fw-semibold "style="margin: 1em;">Events</p>
           <ul>
             <span class="list-group-item list-group-item-action py-3 lh-tight" aria-current="true">

--- a/_series/2022_04_28-seminar_1.md
+++ b/_series/2022_04_28-seminar_1.md
@@ -1,8 +1,7 @@
 ---
 layout: series
 title:  "1st HiRSE Seminar"
-start_date: 28.04.2022
-end_date: 28.04.2022
+start_date: 2022-04-28
 location: virtual
 excerpt_separator: <!--more-->
 ---

--- a/_series/2022_05_20-seminar_2.md
+++ b/_series/2022_05_20-seminar_2.md
@@ -1,8 +1,7 @@
 ---
 layout: series
 title:  "2nd HiRSE Seminar"
-start_date: 20.05.2022
-end_date: 20.05.2022
+start_date: 2022-05-20
 location: virtual
 excerpt_separator: <!--more-->
 ---

--- a/_series/2022_06_10-seminar_3.md
+++ b/_series/2022_06_10-seminar_3.md
@@ -1,8 +1,7 @@
 ---
 layout: series
 title:  "3rd HiRSE Seminar"
-start_date: 10.06.2022
-end_date: 10.06.2022
+start_date: 2022-06-10
 location: virtual
 excerpt_separator: <!--more-->
 ---

--- a/_series/2022_06_24-seminar_4.md
+++ b/_series/2022_06_24-seminar_4.md
@@ -1,8 +1,7 @@
 ---
 layout: series
 title:  "4th HiRSE Seminar"
-start_date: 24.06.2022
-end_date: 24.06.2022
+start_date: 2022-06-24
 location: virtual
 excerpt_separator: <!--more-->
 ---

--- a/_series/2022_09_15-seminar_5.md
+++ b/_series/2022_09_15-seminar_5.md
@@ -1,8 +1,7 @@
 ---
 layout: series
 title:  "5th HiRSE Seminar"
-start_date: 15.09.2022
-end_date: 15.09.2022
+start_date: 2022-09-15
 location: virtual
 excerpt_separator: <!--more-->
 ---

--- a/_series/2022_10_07-seminar_6.md
+++ b/_series/2022_10_07-seminar_6.md
@@ -1,8 +1,7 @@
 ---
 layout: series
 title:  "6th HiRSE Seminar"
-start_date: 13.10.2022
-end_date: 13.10.2022
+start_date: 2022-10-13
 location: virtual
 excerpt_separator: <!--more-->
 ---

--- a/_series/2022_10_27-seminar_7.md
+++ b/_series/2022_10_27-seminar_7.md
@@ -1,8 +1,7 @@
 ---
 layout: series
 title:  "7th HiRSE Seminar, at FZJ OS Week"
-start_date: 27.10.2022
-end_date: 27.10.2022
+start_date: 2022-10-27
 location: virtual
 excerpt_separator: <!--more-->
 ---

--- a/_series/2022_11_10-seminar_8.md
+++ b/_series/2022_11_10-seminar_8.md
@@ -1,8 +1,7 @@
 ---
 layout: series
 title:  "8th HiRSE Seminar"
-start_date: 10.11.2022
-end_date: 10.11.2022
+start_date: 2022-11-10
 location: virtual
 excerpt_separator: <!--more-->
 ---

--- a/_series/2022_12_01-seminar_9.md
+++ b/_series/2022_12_01-seminar_9.md
@@ -1,8 +1,7 @@
 ---
 layout: series
 title:  "9th HiRSE Seminar"
-start_date: 01.12.2022
-end_date: 01.12.2022
+start_date: 2022-12-01
 location: virtual
 excerpt_separator: <!--more-->
 ---

--- a/_series/2022_12_07-seminar_10.md
+++ b/_series/2022_12_07-seminar_10.md
@@ -1,8 +1,7 @@
 ---
 layout: series
 title:  "10th HiRSE Seminar"
-start_date: 07.12.2022
-end_date: 07.12.2022
+start_date: 2022-12-07
 location: virtual
 excerpt_separator: <!--more-->
 ---

--- a/_series/2023_01_23-seminar_11.md
+++ b/_series/2023_01_23-seminar_11.md
@@ -1,8 +1,7 @@
 ---
 layout: series
 title:  "11th HiRSE Seminar"
-start_date: 23.01.2023
-end_date: 23.01.2023
+start_date: 2023-01-23
 location: virtual
 excerpt_separator: <!--more-->
 ---

--- a/_series/2023_02_13-seminar_12.md
+++ b/_series/2023_02_13-seminar_12.md
@@ -1,8 +1,7 @@
 ---
 layout: series
 title:  "12th HiRSE Seminar"
-start_date: 13.02.2023
-end_date: 13.02.2023
+start_date: 2023-02-13
 location: virtual
 excerpt_separator: <!--more-->
 ---

--- a/_series/2023_03_09-seminar_13.md
+++ b/_series/2023_03_09-seminar_13.md
@@ -1,8 +1,7 @@
 ---
 layout: series
 title:  "13th HiRSE Seminar"
-start_date: 09.03.2023
-end_date: 09.03.2023
+start_date: 2023-03-09
 location: virtual
 excerpt_separator: <!--more-->
 ---

--- a/_series/2023_03_29-seminar_14.md
+++ b/_series/2023_03_29-seminar_14.md
@@ -1,8 +1,7 @@
 ---
 layout: series
 title:  "14th HiRSE Seminar"
-start_date: 29.03.2023
-end_date: 29.03.2023
+start_date: 2023-03-29
 location: virtual
 excerpt_separator: <!--more-->
 ---

--- a/_series/2023_04_26-seminar_15.md
+++ b/_series/2023_04_26-seminar_15.md
@@ -1,8 +1,7 @@
 ---
 layout: series
 title:  "15th HiRSE Seminar"
-start_date: 26.04.2023
-end_date: 26.04.2023
+start_date: 2023-04-26
 location: virtual
 excerpt_separator: <!--more-->
 ---

--- a/_series/2023_05_10-seminar_16.md
+++ b/_series/2023_05_10-seminar_16.md
@@ -1,8 +1,7 @@
 ---
 layout: series
 title:  "16th HiRSE Seminar"
-start_date: 10.05.2023
-end_date: 10.05.2023
+start_date: 2023-05-10
 location: virtual
 excerpt_separator: <!--more-->
 ---

--- a/_series/2023_05_30-seminar_17.md
+++ b/_series/2023_05_30-seminar_17.md
@@ -1,8 +1,7 @@
 ---
 layout: series
 title:  "17th HiRSE Seminar"
-start_date: 30.05.2023
-end_date: 30.05.2023
+start_date: 2023-05-30
 location: virtual
 excerpt_separator: <!--more-->
 ---

--- a/_series/2023_06_27-seminar_18.md
+++ b/_series/2023_06_27-seminar_18.md
@@ -1,8 +1,7 @@
 ---
 layout: series
 title:  "18th HiRSE Seminar"
-start_date: 27.06.2023
-end_date: 27.06.2023
+start_date: 2023-06-27
 location: virtual
 excerpt_separator: <!--more-->
 ---


### PR DESCRIPTION
This PR does addresses two aspects
1) Rewrite the date format for events and the seminar series as yyyy/mm/dd
2) Include both events and seminar series on the main page.

Part 1) was introducted, in order to make sorting by date more straight forward.
In addition, end-dates are dropped for events and seminar series taking place only on a single day.